### PR TITLE
refactor: changes rule to show all `sessoes` into `transacoes`

### DIFF
--- a/pages/dashboard/transacoes/index.tsx
+++ b/pages/dashboard/transacoes/index.tsx
@@ -133,18 +133,13 @@ function obterValorRepasse(sessao: any): number {
 }
 
 // Função para filtrar sessões apenas pelo mês (usando data do agendamento)
-// e excluir sessões com status "Pagamento Pendente"
+// Agora todas as sessões são incluídas, independentemente do status
 const filterSessoesByMonth = (sessoes: any[], selectedMonth: Date): any[] => {
   if (!Array.isArray(sessoes)) {
     return [];
   }
 
   return sessoes.filter((sessao) => {
-    // Filtrar apenas sessões que não estão com "Pagamento Pendente"
-    if (sessao.statusSessao === "Pagamento Pendente") {
-      return false;
-    }
-
     // Usar a data do agendamento associado
     const dataAgendamento = sessao.agendamentoInfo?.dataAgendamento;
 
@@ -286,8 +281,8 @@ export default function Transacoes() {
 
   const transacoesSessoes = useMemo(() => {
     return sessoesDoMes.flatMap((sessao) => {
-      // Nota: Apenas sessões com status diferente de "Pagamento Pendente"
-      // são incluídas no dashboard financeiro
+      // Nota: Todas as sessões agora são incluídas no dashboard financeiro
+      // independentemente do status de pagamento
       const repasse = obterValorRepasse(sessao);
 
       // Usar a data do agendamento associado

--- a/utils/dateUtils.ts
+++ b/utils/dateUtils.ts
@@ -233,22 +233,23 @@ export function formatSessaoDate(sessao: any): string {
 
 /**
  * Filtrar sessões por status de pagamento
- * Útil para incluir apenas sessões pagas nas transações
+ * Nota: Função removida - agora todas as sessões aparecem nas transações
+ * Mantida para compatibilidade mas retorna todas as sessões
  */
 export function filterSessoesPagas(sessoes: any[]): any[] {
   if (!Array.isArray(sessoes)) {
     return [];
   }
 
-  return sessoes.filter((sessao) => {
-    // Incluir apenas sessões que NÃO estão com "Pagamento Pendente"
-    return sessao.statusSessao !== "Pagamento Pendente";
-  });
+  // Retorna todas as sessões - filtro de status removido
+  return sessoes;
 }
 
 /**
  * Verificar se uma sessão deve aparecer nas transações financeiras
+ * Nota: Função removida - agora todas as sessões aparecem nas transações
  */
-export function sessaoDeveAparecerNasTransacoes(sessao: any): boolean {
-  return sessao?.statusSessao !== "Pagamento Pendente";
+export function sessaoDeveAparecerNasTransacoes(_sessao: any): boolean {
+  // Retorna sempre true - todas as sessões devem aparecer
+  return true;
 }


### PR DESCRIPTION
This pull request updates the logic for handling financial transactions in the dashboard by removing the filtering of sessions based on payment status. All sessions, regardless of their payment status, are now included in the dashboard and related utilities. Below is a summary of the key changes:

### Dashboard Logic Updates

* [`pages/dashboard/transacoes/index.tsx`](diffhunk://#diff-83d5aef137126d04f42e6f26720f862389e2d0a99818a2aa33d59c71decc9c20L136-L147): Updated the `filterSessoesByMonth` function to no longer exclude sessions with the "Pagamento Pendente" status. All sessions are now included based on their scheduling date.
* [`pages/dashboard/transacoes/index.tsx`](diffhunk://#diff-83d5aef137126d04f42e6f26720f862389e2d0a99818a2aa33d59c71decc9c20L289-R285): Modified the `Transacoes` component to ensure all sessions, regardless of payment status, are included in the financial dashboard.

### Utility Function Adjustments

* [`utils/dateUtils.ts`](diffhunk://#diff-466bccf2616eccb16a6cf3f388680c327295a216316ef6e51fe145f0cd02f60bL236-R254): Updated the `filterSessoesPagas` function to remove the filtering logic for payment status. The function now returns all sessions for compatibility purposes.
* [`utils/dateUtils.ts`](diffhunk://#diff-466bccf2616eccb16a6cf3f388680c327295a216316ef6e51fe145f0cd02f60bL236-R254): Adjusted the `sessaoDeveAparecerNasTransacoes` function to always return `true`, ensuring all sessions are included in financial transactions.