### PR TITLE
style: update layout `faturamento`

### DIFF
--- a/pages/api/v1/faturamento/index.js
+++ b/pages/api/v1/faturamento/index.js
@@ -91,6 +91,31 @@ async function getHandler(req, res) {
           calcularRepasse(s.valor_sessao, s.terapeuta_dt_entrada);
         return acc + parseFloat(repasse || 0);
       }, 0),
+      percentualRepasseMedio:
+        sessoes.length > 0
+          ? Math.round(
+              sessoes.reduce((acc, s) => {
+                let percentual = 45;
+                if (
+                  s.valor_repasse !== undefined &&
+                  s.valor_repasse !== null &&
+                  s.valor_sessao > 0
+                ) {
+                  percentual = Math.round(
+                    (s.valor_repasse / s.valor_sessao) * 100,
+                  );
+                } else if (s.terapeuta_dt_entrada) {
+                  const dataEntrada = new Date(s.terapeuta_dt_entrada);
+                  const hoje = new Date();
+                  const diffMs = hoje.getTime() - dataEntrada.getTime();
+                  const umAnoMs = 365.25 * 24 * 60 * 60 * 1000;
+                  const anosNaClinica = diffMs / umAnoMs;
+                  percentual = anosNaClinica >= 1 ? 50 : 45;
+                }
+                return acc + percentual;
+              }, 0) / sessoes.length,
+            )
+          : 0,
     };
 
     return res.status(200).json({


### PR DESCRIPTION
This pull request introduces several updates to the `faturamento` feature, focusing on backend calculations, UI improvements, and code cleanup. The most notable changes include moving the calculation of `percentualRepasseMedio` to the backend, enhancing the UI for better responsiveness and accessibility, and simplifying the code by removing unnecessary logic.

### Backend Updates:
* Added the calculation of `percentualRepasseMedio` to the backend in `pages/api/v1/faturamento/index.js` to centralize logic and reduce frontend complexity.

### UI Improvements:
* Redesigned the `Faturamento` page to improve responsiveness, accessibility, and visual hierarchy. This includes updating headers, navigation, filters, and session tables for a more modern and user-friendly experience. [[1]](diffhunk://#diff-08325c8f782c4d6aa5829ddcfbb1fe32047b4938dd0e903af1f6f5d5efa405f6L121-R98) [[2]](diffhunk://#diff-08325c8f782c4d6aa5829ddcfbb1fe32047b4938dd0e903af1f6f5d5efa405f6L152-R259) [[3]](diffhunk://#diff-08325c8f782c4d6aa5829ddcfbb1fe32047b4938dd0e903af1f6f5d5efa405f6L301-R324) [[4]](diffhunk://#diff-08325c8f782c4d6aa5829ddcfbb1fe32047b4938dd0e903af1f6f5d5efa405f6L337-R341)
* Enhanced empty state handling for the session table with a more descriptive and visually appealing message using the `CalendarCheck` icon.

### Code Cleanup:
* Removed the `useMemo` logic for calculating `percentualRepasseMedio` and filtered totals in the frontend, as these calculations are now handled by the backend.
* Removed unused imports, such as `useMemo` and `Tag`, to streamline the codebase. [[1]](diffhunk://#diff-08325c8f782c4d6aa5829ddcfbb1fe32047b4938dd0e903af1f6f5d5efa405f6L1-R4) [[2]](diffhunk://#diff-08325c8f782c4d6aa5829ddcfbb1fe32047b4938dd0e903af1f6f5d5efa405f6L13)