### PR TITLE
refactor: refactor table `pacientes` to make `dt_nascimento` and `origem` fields optional

### DIFF
--- a/components/Paciente/pacienteSchema.ts
+++ b/components/Paciente/pacienteSchema.ts
@@ -3,10 +3,11 @@ import { z } from "zod";
 // Define o schema do formulário
 export const PacienteFormSchema = z.object({
   nome: z.string().min(3, { message: "O nome é obrigatório" }),
-  dt_nascimento: z.date({
-    required_error: "A data de nascimento é obrigatória",
-    invalid_type_error: "Data de nascimento inválida",
-  }),
+  dt_nascimento: z
+    .date({
+      invalid_type_error: "Data de nascimento inválida",
+    })
+    .optional(),
   terapeuta_id: z.string().min(1, {
     message: "Terapeuta responsável é obrigatório",
   }),
@@ -25,7 +26,7 @@ export const PacienteFormSchema = z.object({
   endereco_responsavel: z.string().min(5, {
     message: "O endereço do responsável é obrigatório",
   }),
-  origem: z.string().min(1, { message: "Origem é obrigatória" }),
+  origem: z.string().optional(),
   dt_entrada: z.date({
     required_error: "A data de entrada é obrigatória",
     invalid_type_error: "Data de entrada inválida",

--- a/infra/migrations/20250707082424_make-paciente-fields-optional.js
+++ b/infra/migrations/20250707082424_make-paciente-fields-optional.js
@@ -1,0 +1,29 @@
+exports.up = (pgm) => {
+  // Tornar o campo dt_nascimento opcional
+  pgm.alterColumn("pacientes", "dt_nascimento", {
+    type: "date",
+    notNull: false,
+  });
+
+  // Tornar o campo origem opcional
+  pgm.alterColumn("pacientes", "origem", {
+    type: "varchar(50)",
+    notNull: false,
+    check: `origem IN ('Indicação', 'Instagram', 'Busca no Google', 'Outros') OR origem IS NULL`,
+  });
+};
+
+exports.down = (pgm) => {
+  // Reverter as alterações - tornar os campos obrigatórios novamente
+  // ATENÇÃO: Esta operação pode falhar se existirem registros com valores NULL
+  pgm.alterColumn("pacientes", "dt_nascimento", {
+    type: "date",
+    notNull: true,
+  });
+
+  pgm.alterColumn("pacientes", "origem", {
+    type: "varchar(50)",
+    notNull: true,
+    check: `origem IN ('Indicação', 'Instagram', 'Busca no Google', 'Outros')`,
+  });
+};

--- a/infra/scripts/seed-pacientes.js
+++ b/infra/scripts/seed-pacientes.js
@@ -5,6 +5,8 @@
  *
  * Este script insere dados fictícios na tabela de pacientes para facilitar o desenvolvimento
  * e testes da aplicação. Não deve ser usado em ambiente de produção.
+ *
+ * Nota: Os campos dt_nascimento e origem são opcionais e podem ser null em alguns registros.
  */
 
 const database = require("../database.js");
@@ -92,10 +94,12 @@ async function seedPacientes() {
     for (let i = existingCount; i < NUM_PACIENTES; i++) {
       // Gerar dados fictícios usando faker
       const nome = faker.person.fullName();
-      const dt_nascimento = randomDate(
-        new Date(1990, 0, 1),
-        new Date(2020, 0, 1),
-      );
+
+      // dt_nascimento é opcional - 30% de chance de ser null
+      const dt_nascimento =
+        Math.random() > 0.3
+          ? randomDate(new Date(1990, 0, 1), new Date(2020, 0, 1))
+          : null;
 
       // Selecionar um terapeuta aleatoriamente
       const terapeuta_id =
@@ -107,7 +111,13 @@ async function seedPacientes() {
       const cpf_responsavel = faker.string.numeric(11);
       const endereco_responsavel =
         faker.location.streetAddress() + ", " + faker.location.city();
-      const origem = origens[Math.floor(Math.random() * origens.length)];
+
+      // origem é opcional - 20% de chance de ser null
+      const origem =
+        Math.random() > 0.2
+          ? origens[Math.floor(Math.random() * origens.length)]
+          : null;
+
       const dt_entrada = randomDate(new Date(2022, 0, 1), new Date());
 
       // Inserir no banco

--- a/pages/api/v1/pacientes/[id]/index.js
+++ b/pages/api/v1/pacientes/[id]/index.js
@@ -78,7 +78,9 @@ async function putHandler(request, response) {
     const pacienteData = {
       nome: getFormValue(fields.nome) || pacienteExists.nome,
       dt_nascimento:
-        getFormValue(fields.dt_nascimento) || pacienteExists.dt_nascimento,
+        getFormValue(fields.dt_nascimento) !== undefined
+          ? getFormValue(fields.dt_nascimento) || null
+          : pacienteExists.dt_nascimento,
       // Use o valor do form apenas se não for falsy (empty string, null, etc)
       terapeuta_id: terapeuta_id || pacienteExists.terapeuta_id,
       nome_responsavel:
@@ -95,7 +97,10 @@ async function putHandler(request, response) {
       endereco_responsavel:
         getFormValue(fields.endereco_responsavel) ||
         pacienteExists.endereco_responsavel,
-      origem: getFormValue(fields.origem) || pacienteExists.origem,
+      origem:
+        getFormValue(fields.origem) !== undefined
+          ? getFormValue(fields.origem) || null
+          : pacienteExists.origem,
       dt_entrada: getFormValue(fields.dt_entrada) || pacienteExists.dt_entrada,
     };
 

--- a/pages/api/v1/pacientes/index.js
+++ b/pages/api/v1/pacientes/index.js
@@ -69,28 +69,26 @@ async function postHandler(request, response) {
     // Preparar objeto paciente para inserção com os campos corretos
     const pacienteData = {
       nome: getFormValue(fields.nome),
-      dt_nascimento: getFormValue(fields.dt_nascimento),
+      dt_nascimento: getFormValue(fields.dt_nascimento) || null,
       terapeuta_id: getFormValue(fields.terapeuta_id),
       nome_responsavel: getFormValue(fields.nome_responsavel),
       telefone_responsavel: getFormValue(fields.telefone_responsavel),
       email_responsavel: getFormValue(fields.email_responsavel),
       cpf_responsavel: getFormValue(fields.cpf_responsavel),
       endereco_responsavel: getFormValue(fields.endereco_responsavel),
-      origem: getFormValue(fields.origem),
+      origem: getFormValue(fields.origem) || null,
       dt_entrada: getFormValue(fields.dt_entrada),
     };
 
-    // Validação dos campos obrigatórios
+    // Validação dos campos obrigatórios (removendo dt_nascimento e origem)
     const requiredFields = [
       "nome",
-      "dt_nascimento",
       "terapeuta_id",
       "nome_responsavel",
       "telefone_responsavel",
       "email_responsavel",
       "cpf_responsavel",
       "endereco_responsavel",
-      "origem",
     ];
 
     for (const field of requiredFields) {

--- a/store/pacientesSlice.ts
+++ b/store/pacientesSlice.ts
@@ -58,11 +58,16 @@ const preparePacienteData = (data: any) => {
     }
   };
 
-  // Garante que dt_nascimento NUNCA será null
-  formattedData.dt_nascimento = formatDateToYYYYMMDD(
-    formattedData.dt_nascimento,
-  );
-  console.log("dt_nascimento formatado final:", formattedData.dt_nascimento);
+  // Formatar dt_nascimento apenas se estiver presente
+  if (formattedData.dt_nascimento) {
+    formattedData.dt_nascimento = formatDateToYYYYMMDD(
+      formattedData.dt_nascimento,
+    );
+    console.log("dt_nascimento formatado final:", formattedData.dt_nascimento);
+  } else {
+    formattedData.dt_nascimento = null;
+    console.log("dt_nascimento não preenchido, definindo como null");
+  }
 
   // Garante que dt_entrada NUNCA será null
   formattedData.dt_entrada = formatDateToYYYYMMDD(formattedData.dt_entrada);
@@ -99,9 +104,10 @@ const preparePacienteData = (data: any) => {
     throw new Error("Endereço do responsável é obrigatório");
   }
 
+  // Origem é opcional, mantém valor original ou define como null
   if (!formattedData.origem) {
-    console.warn("Origem não definida, usando 'Outros'");
-    formattedData.origem = "Outros";
+    formattedData.origem = null;
+    console.log("Origem não definida, definindo como null");
   }
 
   console.log("Dados formatados para envio:", formattedData);

--- a/tipos.ts
+++ b/tipos.ts
@@ -18,7 +18,7 @@ export interface Terapeuta {
 export interface Paciente {
   id: string;
   nome: string;
-  dt_nascimento: Date | string;
+  dt_nascimento?: Date | string | null;
   terapeuta_id: string;
   terapeutaInfo?: Terapeuta;
   nome_responsavel: string;
@@ -26,7 +26,7 @@ export interface Paciente {
   email_responsavel: string;
   cpf_responsavel: string;
   endereco_responsavel: string;
-  origem: "Indicação" | "Instagram" | "Busca no Google" | "Outros";
+  origem?: "Indicação" | "Instagram" | "Busca no Google" | "Outros" | null;
   dt_entrada: Date | string;
   created_at?: string;
   updated_at?: string;


### PR DESCRIPTION
This pull request introduces changes to make the `dt_nascimento` and `origem` fields optional across the application, including schema definitions, database migrations, API handlers, seeding scripts, and TypeScript types. These updates ensure consistency and flexibility when handling these fields, allowing them to be null or undefined where applicable.

### Schema and Validation Updates:
* Updated `PacienteFormSchema` in `pacienteSchema.ts` to make `dt_nascimento` and `origem` optional. (`[[1]](diffhunk://#diff-27a29fbcd17e983d9e0407a26b3aa19613cb035162683f1bd0944ad688b99966L6-R10)`, `[[2]](diffhunk://#diff-27a29fbcd17e983d9e0407a26b3aa19613cb035162683f1bd0944ad688b99966L28-R29)`)

### Database Changes:
* Added a migration script to make the `dt_nascimento` and `origem` fields optional in the `pacientes` table, with appropriate constraints for `origem`. (`[infra/migrations/20250707082424_make-paciente-fields-optional.jsR1-R29](diffhunk://#diff-c65911bae572af5d798a7fbb6e5a9cdbf9e4c6268b8971a204cadd9757414286R1-R29)`)

### API Adjustments:
* Modified `putHandler` and `postHandler` in `pages/api/v1/pacientes` to handle optional `dt_nascimento` and `origem` fields, ensuring null values are correctly managed. (`[pages/api/v1/pacientes/[id]/index.jsL81-R83](diffhunk://#diff-cfd07b85a3ef6774f31449163127becedd2d67b91f3311501aa3532c0e21f18fL81-R83)`, `[pages/api/v1/pacientes/[id]/index.jsL98-R103](diffhunk://#diff-cfd07b85a3ef6774f31449163127becedd2d67b91f3311501aa3532c0e21f18fL98-R103)`, `[pages/api/v1/pacientes/index.jsL72-L93](diffhunk://#diff-cf71c6de89ba340909c7cc7300978366cfc8d9d84c1c05382d0f20a88e1c93e4L72-L93)`)

### Data Seeding:
* Updated `seed-pacientes.js` to reflect the optional nature of `dt_nascimento` (30% chance of null) and `origem` (20% chance of null) when generating test data. (`[[1]](diffhunk://#diff-f70e639b45c9634bdbfba8306529e0d071f198f0de36530546617ca89c65774cL95-R102)`, `[[2]](diffhunk://#diff-f70e639b45c9634bdbfba8306529e0d071f198f0de36530546617ca89c65774cL110-R120)`)

### TypeScript Type Updates:
* Adjusted the `Paciente` interface in `tipos.ts` to mark `dt_nascimento` and `origem` as optional and nullable, aligning with the database and schema changes. (`[tipos.tsL21-R29](diffhunk://#diff-16c92a407f7c32ab345e32eafc19629665b45835a2caccb75924195d10a3140fL21-R29)`)