### PR TITLE
fix: changes whatsapp number at `home` page

### DIFF
--- a/lighthouse-report.json
+++ b/lighthouse-report.json
@@ -2687,7 +2687,7 @@
                 "width": 115,
                 "height": 24
               },
-              "snippet": "<a href=\"tel:+5561992095674\" class=\"text-azul hover:underline\">",
+              "snippet": "<a href=\"tel:+5561992968282\" class=\"text-azul hover:underline\">",
               "nodeLabel": "(61) 99209-5674",
               "explanation": "Fix any of the following:\n  Element has insufficient color contrast of 3.47 (foreground color: #3395ae, background color: #ffffff, font size: 12.0pt (16px), font weight: normal). Expected contrast ratio of 4.5:1"
             },
@@ -2771,7 +2771,7 @@
                 "width": 380,
                 "height": 72
               },
-              "snippet": "<a href=\"https://wa.me/5561992095674?text=Olá,%20gostaria%20de%20agendar%20uma%20co…\" class=\"bg-rosa text-white px-8 py-3 rounded-full font-medium hover:bg-opacity-90 …\" target=\"_blank\" rel=\"noopener noreferrer\">",
+              "snippet": "<a href=\"https://wa.me/5561992968282?text=Olá,%20gostaria%20de%20agendar%20uma%20co…\" class=\"bg-rosa text-white px-8 py-3 rounded-full font-medium hover:bg-opacity-90 …\" target=\"_blank\" rel=\"noopener noreferrer\">",
               "nodeLabel": "Agende um atendimento com a nossa equipe",
               "explanation": "Fix any of the following:\n  Element has insufficient color contrast of 4.26 (foreground color: #ffffff, background color: #c3586a, font size: 12.0pt (16px), font weight: normal). Expected contrast ratio of 4.5:1"
             }
@@ -2874,7 +2874,7 @@
                 "width": 260,
                 "height": 24
               },
-              "snippet": "<a href=\"tel:+5561992095674\" class=\"text-white/80 hover:text-white flex items-center justify-center md:justify…\">",
+              "snippet": "<a href=\"tel:+5561992968282\" class=\"text-white/80 hover:text-white flex items-center justify-center md:justify…\">",
               "nodeLabel": "(61) 99209-5674",
               "explanation": "Fix any of the following:\n  Element has insufficient color contrast of 2.78 (foreground color: #d6eaef, background color: #3395ae, font size: 12.0pt (16px), font weight: normal). Expected contrast ratio of 4.5:1"
             },

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -381,7 +381,7 @@ function Home() {
                   <div className="flex items-center">
                     <Phone size={24} weight="fill" className="text-rosa mr-2" />
                     <a
-                      href="tel:+5561992095674"
+                      href="tel:+5561992968282"
                       className="text-azul hover:underline"
                     >
                       (61) 99209-5674
@@ -411,7 +411,7 @@ function Home() {
                   Dialógico.
                 </p>
                 <a
-                  href="https://wa.me/5561992095674?text=Olá,%20gostaria%20de%20agendar%20uma%20consulta%20no%20Espaço%20Dialógico"
+                  href="https://wa.me/5561992968282?text=Olá,%20gostaria%20de%20agendar%20uma%20consulta%20no%20Espaço%20Dialógico"
                   className="bg-rosa text-white px-8 py-3 rounded-full font-medium hover:bg-opacity-90 transition-all inline-flex items-center"
                   target="_blank"
                   rel="noopener noreferrer"
@@ -444,7 +444,7 @@ function Home() {
             <div className="flex flex-col space-y-2 text-center md:text-left">
               <h3 className="font-semibold text-lg mb-2">Contato</h3>
               <a
-                href="tel:+5561992095674"
+                href="tel:+5561992968282"
                 className="text-white/80 hover:text-white flex items-center justify-center md:justify-start"
               >
                 <Phone size={16} className="mr-2" /> (61) 99209-5674


### PR DESCRIPTION
This pull request updates the contact phone number throughout the codebase and in the Lighthouse accessibility report, ensuring consistency for both direct phone links and WhatsApp links.

**Contact Information Update:**

* Updated all instances of the phone link in `pages/index.tsx` to use the new number `+5561992968282` instead of the previous `+5561992095674`. This affects both tel: and WhatsApp links. [[1]](diffhunk://#diff-aa98fd0757d0e1741503c50cfafb7726939d19819638bbe8e030a27adfec34a3L384-R384) [[2]](diffhunk://#diff-aa98fd0757d0e1741503c50cfafb7726939d19819638bbe8e030a27adfec34a3L414-R414) [[3]](diffhunk://#diff-aa98fd0757d0e1741503c50cfafb7726939d19819638bbe8e030a27adfec34a3L447-R447)
* Updated the phone number references in the `lighthouse-report.json` file to reflect the new number in both tel: and WhatsApp links. [[1]](diffhunk://#diff-e2058a27c2b2c6aee584fb7274e556dded3c009268262f370580c04b56c53be7L2690-R2690) [[2]](diffhunk://#diff-e2058a27c2b2c6aee584fb7274e556dded3c009268262f370580c04b56c53be7L2774-R2774) [[3]](diffhunk://#diff-e2058a27c2b2c6aee584fb7274e556dded3c009268262f370580c04b56c53be7L2877-R2877)