### PR TITLE
fix: sincroniza valor do agendamento com sessão/NF na edição

### DIFF
--- a/pages/api/v1/agendamentos/[id]/index.js
+++ b/pages/api/v1/agendamentos/[id]/index.js
@@ -135,16 +135,6 @@ async function putHandler(req, res) {
     // Atualizar apenas este agendamento específico
     const agendamentoAtualizado = await agendamento.update(id, agendamentoData);
 
-    // Suporte a ambos os formatos camelCase e snake_case
-    // Prioriza o valor do banco (snake_case), mas aceita camelCase vindo do frontend
-    const sessaoRealizadaAntes =
-      agendamentoAntes.sessao_realizada !== undefined
-        ? agendamentoAntes.sessao_realizada
-        : agendamentoAntes.sessaoRealizada;
-
-    const faltaAntes =
-      agendamentoAntes.falta !== undefined ? agendamentoAntes.falta : false;
-
     // O model pode retornar camelCase ou snake_case dependendo do mapeamento
     // e o update pode não atualizar ambos, então garantimos aqui
     const sessaoRealizadaDepois =
@@ -157,56 +147,122 @@ async function putHandler(req, res) {
         ? agendamentoAtualizado.falta
         : false;
 
-    // Se `sessaoRealizada` OU `falta` mudou para true E não está cancelado, criar a sessão
-    const deveCriarSessaoAntes = sessaoRealizadaAntes || faltaAntes;
-    const deveCriarSessaoDepois = sessaoRealizadaDepois || faltaDepois;
+    const statusAgendamentoDepois = obterCampo(
+      agendamentoAtualizado,
+      "statusAgendamento",
+      "status_agendamento",
+    );
+    const deveExistirSessaoDepois =
+      (sessaoRealizadaDepois || faltaDepois) &&
+      statusAgendamentoDepois !== "Cancelado";
 
-    if (
-      !deveCriarSessaoAntes &&
-      deveCriarSessaoDepois &&
-      agendamentoAtualizado.statusAgendamento !== "Cancelado"
-    ) {
-      try {
-        const sessaoData = {
-          terapeuta_id: agendamentoAtualizado.terapeuta_id,
-          paciente_id: agendamentoAtualizado.paciente_id,
-          tipoSessao: mapearTipoAgendamentoParaTipoSessao(
-            agendamentoAtualizado.tipoAgendamento,
-          ),
-          valorSessao: agendamentoAtualizado.valorAgendamento,
-          statusSessao: "Pagamento Pendente",
-          agendamento_id: agendamentoAtualizado.id,
-        };
-        await sessao.create(sessaoData);
-      } catch (error) {
-        console.error(
-          "Erro ao criar sessão na atualização do agendamento:",
-          error,
-        );
+    const sessoesAssociadas = await sessao.getFiltered({
+      agendamento_id: id,
+    });
+
+    if (!deveExistirSessaoDepois) {
+      for (const sessaoAssociada of sessoesAssociadas) {
+        await sessao.remove(sessaoAssociada.id);
       }
-    }
-    // Se `sessaoRealizada` E `falta` mudaram para false OU se o status mudou para "Cancelado", remover a sessão associada
-    else if (
-      (deveCriarSessaoAntes && !deveCriarSessaoDepois) ||
-      agendamentoAtualizado.statusAgendamento === "Cancelado"
-    ) {
-      try {
-        const sessoesAssociadas = await sessao.getFiltered({
-          agendamento_id: id,
-        });
-        for (const sessaoAssociada of sessoesAssociadas) {
-          await sessao.remove(sessaoAssociada.id);
-        }
 
-        // Se o agendamento foi cancelado, garantir que sessaoRealizada seja false no banco
-        if (agendamentoAtualizado.statusAgendamento === "Cancelado") {
-          await agendamento.update(id, { sessaoRealizada: false });
+      // Se o agendamento foi cancelado, garantir que sessaoRealizada seja false no banco
+      if (statusAgendamentoDepois === "Cancelado" && sessaoRealizadaDepois) {
+        await agendamento.update(id, { sessaoRealizada: false });
+      }
+    } else if (sessoesAssociadas.length === 0) {
+      const sessaoData = {
+        terapeuta_id: obterCampo(
+          agendamentoAtualizado,
+          "terapeuta_id",
+          "terapeuta_id",
+        ),
+        paciente_id: obterCampo(
+          agendamentoAtualizado,
+          "paciente_id",
+          "paciente_id",
+        ),
+        tipoSessao: mapearTipoAgendamentoParaTipoSessao(
+          obterCampo(
+            agendamentoAtualizado,
+            "tipoAgendamento",
+            "tipo_agendamento",
+          ),
+        ),
+        valorSessao: obterNumeroCampo(
+          agendamentoAtualizado,
+          "valorAgendamento",
+          "valor_agendamento",
+        ),
+        statusSessao: "Pagamento Pendente",
+        agendamento_id: agendamentoAtualizado.id,
+      };
+
+      await sessao.create(sessaoData);
+    } else {
+      const valorAntes = obterNumeroCampo(
+        agendamentoAntes,
+        "valorAgendamento",
+        "valor_agendamento",
+      );
+      const valorDepois = obterNumeroCampo(
+        agendamentoAtualizado,
+        "valorAgendamento",
+        "valor_agendamento",
+      );
+      const tipoAntes = obterCampo(
+        agendamentoAntes,
+        "tipoAgendamento",
+        "tipo_agendamento",
+      );
+      const tipoDepois = obterCampo(
+        agendamentoAtualizado,
+        "tipoAgendamento",
+        "tipo_agendamento",
+      );
+      const terapeutaAntes = obterCampo(
+        agendamentoAntes,
+        "terapeuta_id",
+        "terapeuta_id",
+      );
+      const terapeutaDepois = obterCampo(
+        agendamentoAtualizado,
+        "terapeuta_id",
+        "terapeuta_id",
+      );
+      const pacienteAntes = obterCampo(
+        agendamentoAntes,
+        "paciente_id",
+        "paciente_id",
+      );
+      const pacienteDepois = obterCampo(
+        agendamentoAtualizado,
+        "paciente_id",
+        "paciente_id",
+      );
+
+      const sessaoUpdateData = {};
+
+      if (valorAntes !== valorDepois) {
+        sessaoUpdateData.valorSessao = valorDepois;
+      }
+
+      if (tipoAntes !== tipoDepois) {
+        sessaoUpdateData.tipoSessao =
+          mapearTipoAgendamentoParaTipoSessao(tipoDepois);
+      }
+
+      if (terapeutaAntes !== terapeutaDepois) {
+        sessaoUpdateData.terapeuta_id = terapeutaDepois;
+      }
+
+      if (pacienteAntes !== pacienteDepois) {
+        sessaoUpdateData.paciente_id = pacienteDepois;
+      }
+
+      if (Object.keys(sessaoUpdateData).length > 0) {
+        for (const sessaoAssociada of sessoesAssociadas) {
+          await sessao.update(sessaoAssociada.id, sessaoUpdateData);
         }
-      } catch (error) {
-        console.error(
-          "Erro ao remover sessão na atualização do agendamento:",
-          error,
-        );
       }
     }
 
@@ -294,4 +350,16 @@ function mapearTipoAgendamentoParaTipoSessao(tipoAgendamento) {
     default:
       return "Atendimento";
   }
+}
+
+function obterCampo(obj, campoCamel, campoSnake) {
+  if (!obj) return undefined;
+  if (obj[campoCamel] !== undefined) return obj[campoCamel];
+  return obj[campoSnake];
+}
+
+function obterNumeroCampo(obj, campoCamel, campoSnake) {
+  const valor = obterCampo(obj, campoCamel, campoSnake);
+  if (valor === undefined || valor === null) return valor;
+  return Number(valor);
 }

--- a/pages/api/v1/agendamentos/[id]/index.js
+++ b/pages/api/v1/agendamentos/[id]/index.js
@@ -168,18 +168,21 @@ async function putHandler(req, res) {
       // Se o agendamento foi cancelado, garantir que sessaoRealizada seja false no banco
       if (statusAgendamentoDepois === "Cancelado" && sessaoRealizadaDepois) {
         await agendamento.update(id, { sessaoRealizada: false });
+        // Mantém a resposta consistente com o estado persistido no banco
+        agendamentoAtualizado.sessaoRealizada = false;
+        agendamentoAtualizado.sessao_realizada = false;
       }
     } else if (sessoesAssociadas.length === 0) {
       const sessaoData = {
         terapeuta_id: obterCampo(
           agendamentoAtualizado,
           "terapeuta_id",
-          "terapeuta_id",
+          "terapeutaId",
         ),
         paciente_id: obterCampo(
           agendamentoAtualizado,
           "paciente_id",
-          "paciente_id",
+          "pacienteId",
         ),
         tipoSessao: mapearTipoAgendamentoParaTipoSessao(
           obterCampo(
@@ -222,22 +225,22 @@ async function putHandler(req, res) {
       const terapeutaAntes = obterCampo(
         agendamentoAntes,
         "terapeuta_id",
-        "terapeuta_id",
+        "terapeutaId",
       );
       const terapeutaDepois = obterCampo(
         agendamentoAtualizado,
         "terapeuta_id",
-        "terapeuta_id",
+        "terapeutaId",
       );
       const pacienteAntes = obterCampo(
         agendamentoAntes,
         "paciente_id",
-        "paciente_id",
+        "pacienteId",
       );
       const pacienteDepois = obterCampo(
         agendamentoAtualizado,
         "paciente_id",
-        "paciente_id",
+        "pacienteId",
       );
 
       const sessaoUpdateData = {};

--- a/pages/api/v1/agendamentos/recurrences/[id]/index.js
+++ b/pages/api/v1/agendamentos/recurrences/[id]/index.js
@@ -615,6 +615,16 @@ async function atualizarSessoesDeAgendamentos(agendamentosAtualizados) {
           "valorAgendamento",
           "valor_agendamento",
         );
+        const terapeutaAtual = obterCampoAgendamento(
+          agendamentoAtualizado,
+          "terapeuta_id",
+          "terapeutaId",
+        );
+        const pacienteAtual = obterCampoAgendamento(
+          agendamentoAtualizado,
+          "paciente_id",
+          "pacienteId",
+        );
 
         if (tipoAgendamentoAtual !== undefined) {
           sessaoUpdateData.tipoSessao =
@@ -622,6 +632,12 @@ async function atualizarSessoesDeAgendamentos(agendamentosAtualizados) {
         }
         if (valorAgendamentoAtual !== undefined) {
           sessaoUpdateData.valorSessao = valorAgendamentoAtual;
+        }
+        if (terapeutaAtual !== undefined) {
+          sessaoUpdateData.terapeuta_id = terapeutaAtual;
+        }
+        if (pacienteAtual !== undefined) {
+          sessaoUpdateData.paciente_id = pacienteAtual;
         }
 
         if (Object.keys(sessaoUpdateData).length > 0) {
@@ -712,8 +728,49 @@ async function atualizarSessoesDeAgendamentosOtimizado(
         "status_agendamento",
       );
 
+      let sessaoRealizadaEfetiva = sessaoRealizadaAtual;
+      let faltaEfetiva = faltaAtual;
+      let statusEfetivo = statusAtual;
+
+      // No fluxo otimizado, alguns campos podem não vir no retorno.
+      // Quando faltar informação, buscamos o estado persistido para evitar decisões incorretas.
+      if (
+        sessaoRealizadaEfetiva === undefined ||
+        faltaEfetiva === undefined ||
+        statusEfetivo === undefined
+      ) {
+        const agendamentoPersistido = await agendamento.getById(
+          agendamentoAtualizado.id,
+        );
+
+        if (sessaoRealizadaEfetiva === undefined) {
+          sessaoRealizadaEfetiva = obterBooleanAgendamento(
+            agendamentoPersistido,
+            "sessaoRealizada",
+            "sessao_realizada",
+          );
+        }
+
+        if (faltaEfetiva === undefined) {
+          faltaEfetiva = obterBooleanAgendamento(
+            agendamentoPersistido,
+            "falta",
+            "falta",
+          );
+        }
+
+        if (statusEfetivo === undefined) {
+          statusEfetivo = obterCampoAgendamento(
+            agendamentoPersistido,
+            "statusAgendamento",
+            "status_agendamento",
+          );
+        }
+      }
+
       const shouldCreateSession =
-        (sessaoRealizadaAtual || faltaAtual) && statusAtual !== "Cancelado";
+        (sessaoRealizadaEfetiva || faltaEfetiva) &&
+        statusEfetivo !== "Cancelado";
       const sessionAlreadyExists =
         sessaoExistente && sessaoExistente.length > 0;
 
@@ -734,6 +791,16 @@ async function atualizarSessoesDeAgendamentosOtimizado(
             "valorAgendamento",
             "valor_agendamento",
           );
+          const terapeutaAtual = obterCampoAgendamento(
+            agendamentoAtualizado,
+            "terapeuta_id",
+            "terapeutaId",
+          );
+          const pacienteAtual = obterCampoAgendamento(
+            agendamentoAtualizado,
+            "paciente_id",
+            "pacienteId",
+          );
 
           if (tipoAgendamentoAtual !== undefined) {
             sessaoUpdateData.tipoSessao =
@@ -741,6 +808,12 @@ async function atualizarSessoesDeAgendamentosOtimizado(
           }
           if (valorAgendamentoAtual !== undefined) {
             sessaoUpdateData.valorSessao = valorAgendamentoAtual;
+          }
+          if (terapeutaAtual !== undefined) {
+            sessaoUpdateData.terapeuta_id = terapeutaAtual;
+          }
+          if (pacienteAtual !== undefined) {
+            sessaoUpdateData.paciente_id = pacienteAtual;
           }
 
           if (Object.keys(sessaoUpdateData).length > 1) {
@@ -888,6 +961,7 @@ function obterNumeroCampoAgendamento(obj, campoA, campoB) {
 
 function obterBooleanAgendamento(obj, campoA, campoB) {
   const valor = obterCampoAgendamento(obj, campoA, campoB);
+  if (valor === undefined || valor === null) return undefined;
   return !!valor;
 }
 

--- a/pages/api/v1/agendamentos/recurrences/[id]/index.js
+++ b/pages/api/v1/agendamentos/recurrences/[id]/index.js
@@ -374,22 +374,16 @@ async function putHandler(req, res) {
       const sessaoStartTime = Date.now();
 
       let sessoesAtualizadas;
-      try {
-        if (isProduction || isStaging) {
-          sessoesAtualizadas = await atualizarSessoesDeAgendamentosOtimizado(
-            atualizados,
-            agendamentoData,
-          );
-        } else {
-          sessoesAtualizadas = await atualizarSessoesDeAgendamentos(
-            atualizados,
-            agendamentoData,
-          );
-        }
-      } catch (error) {
-        console.error("Erro ao atualizar sessões:", error);
-        // Não falhar a atualização se houver erro nas sessões
-        sessoesAtualizadas = 0;
+      if (isProduction || isStaging) {
+        sessoesAtualizadas = await atualizarSessoesDeAgendamentosOtimizado(
+          atualizados,
+          agendamentoData,
+        );
+      } else {
+        sessoesAtualizadas = await atualizarSessoesDeAgendamentos(
+          atualizados,
+          agendamentoData,
+        );
       }
 
       const endTime = Date.now();
@@ -577,99 +571,108 @@ const timeoutMs = isStaging ? 30000 : isProduction ? 45000 : 55000;
 export default withTimeout(router.handler(controller.errorHandlers), timeoutMs);
 
 // Função auxiliar para atualizar sessões associadas aos agendamentos
-async function atualizarSessoesDeAgendamentos(
-  agendamentosAtualizados,
-  agendamentoData,
-) {
+async function atualizarSessoesDeAgendamentos(agendamentosAtualizados) {
   console.log("🔄 Atualizando sessões dos agendamentos recorrentes...");
   let sessoesProcessadas = 0;
 
-  try {
-    for (const agendamentoAtualizado of agendamentosAtualizados) {
-      const sessaoExistente = await sessao.getFiltered({
-        agendamento_id: agendamentoAtualizado.id,
-      });
+  for (const agendamentoAtualizado of agendamentosAtualizados) {
+    const sessaoExistente = await sessao.getFiltered({
+      agendamento_id: agendamentoAtualizado.id,
+    });
 
-      const shouldCreateSession =
-        (agendamentoData.sessaoRealizada || agendamentoData.falta) &&
-        agendamentoAtualizado.statusAgendamento !== "Cancelado";
-      const sessionAlreadyExists =
-        sessaoExistente && sessaoExistente.length > 0;
+    const sessaoRealizadaAtual = obterBooleanAgendamento(
+      agendamentoAtualizado,
+      "sessaoRealizada",
+      "sessao_realizada",
+    );
+    const faltaAtual = obterBooleanAgendamento(
+      agendamentoAtualizado,
+      "falta",
+      "falta",
+    );
+    const statusAtual = obterCampoAgendamento(
+      agendamentoAtualizado,
+      "statusAgendamento",
+      "status_agendamento",
+    );
 
-      if (shouldCreateSession) {
-        if (sessionAlreadyExists) {
-          // Atualizar sessão existente
-          const sessaoAssociada = sessaoExistente[0];
-          const sessaoUpdateData = {};
+    const shouldCreateSession =
+      (sessaoRealizadaAtual || faltaAtual) && statusAtual !== "Cancelado";
+    const sessionAlreadyExists = sessaoExistente && sessaoExistente.length > 0;
 
-          if (agendamentoData.tipoAgendamento) {
-            sessaoUpdateData.tipoSessao = mapearTipoAgendamentoParaTipoSessao(
-              agendamentoData.tipoAgendamento,
-            );
-          }
-          if (agendamentoData.valorAgendamento !== undefined) {
-            sessaoUpdateData.valorSessao = agendamentoData.valorAgendamento;
-          }
-          if (agendamentoData.statusAgendamento) {
-            sessaoUpdateData.statusSessao =
-              mapearStatusAgendamentoParaStatusSessao(
-                agendamentoData.statusAgendamento,
-              );
-          }
+    if (shouldCreateSession) {
+      if (sessionAlreadyExists) {
+        const sessaoAssociada = sessaoExistente[0];
+        const sessaoUpdateData = {};
 
-          if (Object.keys(sessaoUpdateData).length > 0) {
-            await sessao.update(sessaoAssociada.id, sessaoUpdateData);
-            sessoesProcessadas++;
-          }
-        } else {
-          // Criar nova sessão
-          const newSessaoData = {
-            terapeuta_id: agendamentoAtualizado.terapeuta_id,
-            paciente_id: agendamentoAtualizado.paciente_id,
-            tipoSessao: mapearTipoAgendamentoParaTipoSessao(
-              agendamentoData.tipoAgendamento,
-            ),
-            valorSessao: agendamentoData.valorAgendamento,
-            statusSessao: mapearStatusAgendamentoParaStatusSessao(
-              agendamentoData.statusAgendamento,
-            ),
-            agendamento_id: agendamentoAtualizado.id,
-          };
-          await sessao.create(newSessaoData);
+        const tipoAgendamentoAtual = obterCampoAgendamento(
+          agendamentoAtualizado,
+          "tipoAgendamento",
+          "tipo_agendamento",
+        );
+        const valorAgendamentoAtual = obterNumeroCampoAgendamento(
+          agendamentoAtualizado,
+          "valorAgendamento",
+          "valor_agendamento",
+        );
+
+        if (tipoAgendamentoAtual !== undefined) {
+          sessaoUpdateData.tipoSessao =
+            mapearTipoAgendamentoParaTipoSessao(tipoAgendamentoAtual);
+        }
+        if (valorAgendamentoAtual !== undefined) {
+          sessaoUpdateData.valorSessao = valorAgendamentoAtual;
+        }
+
+        if (Object.keys(sessaoUpdateData).length > 0) {
+          await sessao.update(sessaoAssociada.id, sessaoUpdateData);
           sessoesProcessadas++;
         }
       } else {
-        // sessaoRealizada é false OU agendamento foi cancelado, então deletar sessão se existir
-        if (sessionAlreadyExists) {
-          await sessao.remove(sessaoExistente[0].id);
-          sessoesProcessadas++;
-        }
-      }
+        const tipoAgendamentoAtual = obterCampoAgendamento(
+          agendamentoAtualizado,
+          "tipoAgendamento",
+          "tipo_agendamento",
+        );
+        const valorAgendamentoAtual = obterNumeroCampoAgendamento(
+          agendamentoAtualizado,
+          "valorAgendamento",
+          "valor_agendamento",
+        );
+        const statusAgendamentoAtual = obterCampoAgendamento(
+          agendamentoAtualizado,
+          "statusAgendamento",
+          "status_agendamento",
+        );
 
-      // Lógica adicional: Se o agendamento foi cancelado, sempre remover a sessão (mesmo que sessaoRealizada seja true)
-      if (
-        agendamentoAtualizado.statusAgendamento === "Cancelado" &&
-        sessionAlreadyExists &&
-        shouldCreateSession
-      ) {
-        try {
-          await sessao.remove(sessaoExistente[0].id);
-          console.log(
-            `Sessão removida para agendamento cancelado: ${agendamentoAtualizado.id}`,
-          );
-        } catch (error) {
-          console.error(
-            `Erro ao remover sessão do agendamento cancelado ${agendamentoAtualizado.id}:`,
-            error,
-          );
-        }
+        const newSessaoData = {
+          terapeuta_id: obterCampoAgendamento(
+            agendamentoAtualizado,
+            "terapeuta_id",
+            "terapeutaId",
+          ),
+          paciente_id: obterCampoAgendamento(
+            agendamentoAtualizado,
+            "paciente_id",
+            "pacienteId",
+          ),
+          tipoSessao: mapearTipoAgendamentoParaTipoSessao(tipoAgendamentoAtual),
+          valorSessao: valorAgendamentoAtual,
+          statusSessao: mapearStatusAgendamentoParaStatusSessao(
+            statusAgendamentoAtual,
+          ),
+          agendamento_id: agendamentoAtualizado.id,
+        };
+        await sessao.create(newSessaoData);
+        sessoesProcessadas++;
       }
+    } else if (sessionAlreadyExists) {
+      await sessao.remove(sessaoExistente[0].id);
+      sessoesProcessadas++;
     }
-
-    console.log(`✅ ${sessoesProcessadas} sessões processadas com sucesso`);
-  } catch (error) {
-    console.error("⚠️ Erro ao processar algumas sessões:", error.message);
   }
+
+  console.log(`✅ ${sessoesProcessadas} sessões processadas com sucesso`);
 
   return sessoesProcessadas;
 }
@@ -677,7 +680,6 @@ async function atualizarSessoesDeAgendamentos(
 // Função auxiliar para atualizar sessões associadas aos agendamentos (método otimizado)
 async function atualizarSessoesDeAgendamentosOtimizado(
   agendamentosAtualizados,
-  agendamentoData,
 ) {
   console.log(
     "🔄 Atualizando sessões dos agendamentos recorrentes (otimizado)...",
@@ -694,70 +696,95 @@ async function atualizarSessoesDeAgendamentosOtimizado(
         agendamento_id: agendamentoAtualizado.id,
       });
 
+      const sessaoRealizadaAtual = obterBooleanAgendamento(
+        agendamentoAtualizado,
+        "sessaoRealizada",
+        "sessao_realizada",
+      );
+      const faltaAtual = obterBooleanAgendamento(
+        agendamentoAtualizado,
+        "falta",
+        "falta",
+      );
+      const statusAtual = obterCampoAgendamento(
+        agendamentoAtualizado,
+        "statusAgendamento",
+        "status_agendamento",
+      );
+
       const shouldCreateSession =
-        (agendamentoData.sessaoRealizada || agendamentoData.falta) &&
-        agendamentoAtualizado.statusAgendamento !== "Cancelado";
+        (sessaoRealizadaAtual || faltaAtual) && statusAtual !== "Cancelado";
       const sessionAlreadyExists =
         sessaoExistente && sessaoExistente.length > 0;
 
       if (shouldCreateSession) {
         if (sessionAlreadyExists) {
-          // Atualizar sessão existente
           const sessaoAssociada = sessaoExistente[0];
           const sessaoUpdateData = {
             id: sessaoAssociada.id,
           };
 
-          if (agendamentoData.tipoAgendamento) {
-            sessaoUpdateData.tipoSessao = mapearTipoAgendamentoParaTipoSessao(
-              agendamentoData.tipoAgendamento,
-            );
+          const tipoAgendamentoAtual = obterCampoAgendamento(
+            agendamentoAtualizado,
+            "tipoAgendamento",
+            "tipo_agendamento",
+          );
+          const valorAgendamentoAtual = obterNumeroCampoAgendamento(
+            agendamentoAtualizado,
+            "valorAgendamento",
+            "valor_agendamento",
+          );
+
+          if (tipoAgendamentoAtual !== undefined) {
+            sessaoUpdateData.tipoSessao =
+              mapearTipoAgendamentoParaTipoSessao(tipoAgendamentoAtual);
           }
-          if (agendamentoData.valorAgendamento !== undefined) {
-            sessaoUpdateData.valorSessao = agendamentoData.valorAgendamento;
-          }
-          if (agendamentoData.statusAgendamento) {
-            sessaoUpdateData.statusSessao =
-              mapearStatusAgendamentoParaStatusSessao(
-                agendamentoData.statusAgendamento,
-              );
+          if (valorAgendamentoAtual !== undefined) {
+            sessaoUpdateData.valorSessao = valorAgendamentoAtual;
           }
 
           if (Object.keys(sessaoUpdateData).length > 1) {
             sessoesParaAtualizar.push(sessaoUpdateData);
           }
         } else {
-          // Criar nova sessão
+          const tipoAgendamentoAtual = obterCampoAgendamento(
+            agendamentoAtualizado,
+            "tipoAgendamento",
+            "tipo_agendamento",
+          );
+          const valorAgendamentoAtual = obterNumeroCampoAgendamento(
+            agendamentoAtualizado,
+            "valorAgendamento",
+            "valor_agendamento",
+          );
+          const statusAgendamentoAtual = obterCampoAgendamento(
+            agendamentoAtualizado,
+            "statusAgendamento",
+            "status_agendamento",
+          );
+
           sessoesParaCriar.push({
-            terapeuta_id: agendamentoAtualizado.terapeuta_id,
-            paciente_id: agendamentoAtualizado.paciente_id,
-            tipoSessao: mapearTipoAgendamentoParaTipoSessao(
-              agendamentoData.tipoAgendamento,
+            terapeuta_id: obterCampoAgendamento(
+              agendamentoAtualizado,
+              "terapeuta_id",
+              "terapeutaId",
             ),
-            valorSessao: agendamentoData.valorAgendamento,
+            paciente_id: obterCampoAgendamento(
+              agendamentoAtualizado,
+              "paciente_id",
+              "pacienteId",
+            ),
+            tipoSessao:
+              mapearTipoAgendamentoParaTipoSessao(tipoAgendamentoAtual),
+            valorSessao: valorAgendamentoAtual,
             statusSessao: mapearStatusAgendamentoParaStatusSessao(
-              agendamentoData.statusAgendamento,
+              statusAgendamentoAtual,
             ),
             agendamento_id: agendamentoAtualizado.id,
           });
         }
-      } else {
-        // sessaoRealizada é false OU agendamento foi cancelado, então deletar sessão se existir
-        if (sessionAlreadyExists) {
-          sessoesParaDeletar.push(sessaoExistente[0].id);
-        }
-      }
-
-      // Lógica adicional: Se o agendamento foi cancelado, sempre remover a sessão
-      if (
-        agendamentoAtualizado.statusAgendamento === "Cancelado" &&
-        sessionAlreadyExists &&
-        shouldCreateSession
-      ) {
-        // Se a sessão não foi adicionada para deletar ainda, adicionar
-        if (!sessoesParaDeletar.includes(sessaoExistente[0].id)) {
-          sessoesParaDeletar.push(sessaoExistente[0].id);
-        }
+      } else if (sessionAlreadyExists) {
+        sessoesParaDeletar.push(sessaoExistente[0].id);
       }
     }
 
@@ -837,10 +864,31 @@ async function atualizarSessoesDeAgendamentosOtimizado(
 
     console.log(`✅ ${sessoesProcessadas} sessões processadas com sucesso`);
   } catch (error) {
-    console.error("⚠️ Erro ao processar algumas sessões:", error.message);
+    console.error(
+      "⚠️ Erro ao processar sessões em recorrência:",
+      error.message,
+    );
+    throw error;
   }
 
   return sessoesProcessadas;
+}
+
+function obterCampoAgendamento(obj, campoA, campoB) {
+  if (!obj) return undefined;
+  if (obj[campoA] !== undefined) return obj[campoA];
+  return obj[campoB];
+}
+
+function obterNumeroCampoAgendamento(obj, campoA, campoB) {
+  const valor = obterCampoAgendamento(obj, campoA, campoB);
+  if (valor === undefined || valor === null) return valor;
+  return Number(valor);
+}
+
+function obterBooleanAgendamento(obj, campoA, campoB) {
+  const valor = obterCampoAgendamento(obj, campoA, campoB);
+  return !!valor;
 }
 
 // Função otimizada para atualizar agendamentos recorrentes (sem alterar dia da semana)

--- a/tests/integration/api/v1/agendamentos/put.test.js
+++ b/tests/integration/api/v1/agendamentos/put.test.js
@@ -14,6 +14,7 @@ const {
 const orchestrator = require("tests/orchestrator.js").default;
 const terapeutaModel = require("models/terapeuta.js").default;
 const pacienteModel = require("models/paciente.js").default;
+const sessaoModel = require("models/sessao.js").default;
 
 const port = process.env.PORT || process.env.NEXT_PUBLIC_PORT || 3000;
 const TEST_NAME = "Agendamentos - Criação e Edição";
@@ -204,6 +205,10 @@ afterAll(() => {
 });
 
 describe("Agendamentos - Criação e Edição", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   test("Deve criar agendamento simples", async () => {
     const { res, body: agendamento } = await createAgendamentoFixture();
 
@@ -311,6 +316,112 @@ describe("Agendamentos - Criação e Edição", () => {
     expect(desmarcarRes.status).toBe(200);
     expect(desmarcado.sessaoRealizada).toBe(false);
     expect(desmarcado.falta).toBe(false);
+  });
+
+  test("Deve sincronizar valor da sessão ao editar apenas valorAgendamento", async () => {
+    const { body: agendamentoBase } = await createAgendamentoFixture();
+
+    const marcarRes = await fetch(`${BASE_URL}${agendamentoBase.id}/`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${adminToken}`,
+      },
+      body: JSON.stringify({
+        sessaoRealizada: true,
+      }),
+    });
+
+    expect(marcarRes.status).toBe(200);
+
+    const sessoesAntes = await sessaoModel.getFiltered({
+      agendamento_id: agendamentoBase.id,
+    });
+
+    expect(sessoesAntes.length).toBeGreaterThan(0);
+    expect(sessoesAntes[0].valorSessao).toBe(180);
+
+    const editarValorRes = await fetch(`${BASE_URL}${agendamentoBase.id}/`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${adminToken}`,
+      },
+      body: JSON.stringify({
+        valorAgendamento: 250,
+      }),
+    });
+
+    expect(editarValorRes.status).toBe(200);
+
+    const sessoesDepois = await sessaoModel.getFiltered({
+      agendamento_id: agendamentoBase.id,
+    });
+
+    expect(sessoesDepois.length).toBeGreaterThan(0);
+    expect(sessoesDepois[0].valorSessao).toBe(250);
+  });
+
+  test("Não deve criar sessão ao editar valor quando sessão não existe", async () => {
+    const { body: agendamentoBase } = await createAgendamentoFixture();
+
+    const sessoesAntes = await sessaoModel.getFiltered({
+      agendamento_id: agendamentoBase.id,
+    });
+    expect(sessoesAntes.length).toBe(0);
+
+    const editarValorRes = await fetch(`${BASE_URL}${agendamentoBase.id}/`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${adminToken}`,
+      },
+      body: JSON.stringify({
+        valorAgendamento: 275,
+      }),
+    });
+
+    expect(editarValorRes.status).toBe(200);
+
+    const sessoesDepois = await sessaoModel.getFiltered({
+      agendamento_id: agendamentoBase.id,
+    });
+    expect(sessoesDepois.length).toBe(0);
+  });
+
+  test("Deve retornar 500 quando houver erro de persistência ao editar valor", async () => {
+    const { res: createRes, body: agendamentoBase } =
+      await createAgendamentoFixture();
+    expect(createRes.status).toBe(201);
+    expect(agendamentoBase).toHaveProperty("id");
+
+    const marcarRes = await fetch(`${BASE_URL}${agendamentoBase.id}/`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${adminToken}`,
+      },
+      body: JSON.stringify({
+        sessaoRealizada: true,
+      }),
+    });
+
+    expect(marcarRes.status).toBe(200);
+
+    const editarValorRes = await fetch(`${BASE_URL}${agendamentoBase.id}/`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${adminToken}`,
+      },
+      body: JSON.stringify({
+        valorAgendamento: "valor-invalido",
+      }),
+    });
+
+    expect(editarValorRes.status).toBe(500);
+    const body = await editarValorRes.json();
+    expect(JSON.stringify(body)).toContain("Erro ao atualizar agendamento");
   });
 
   test("Deve negar edição para terapeuta sem acesso ao agendamento", async () => {
@@ -427,6 +538,72 @@ describe("Agendamentos - Criação e Edição", () => {
     expect(res.status).toBe(200);
     expect(Array.isArray(body.data)).toBe(true);
     expect(body.data.length).toBeGreaterThan(0);
+  });
+
+  test("Deve sincronizar valor das sessões em atualização de recorrência", async () => {
+    const { res, body, recurrenceId } = await createRecurrenceFixture();
+
+    expect(res.status).toBe(201);
+    expect(Array.isArray(body.data)).toBe(true);
+    expect(body.data.length).toBeGreaterThan(0);
+
+    const ativarSessoesRes = await fetch(
+      `${BASE_URL}recurrences/${recurrenceId}/`,
+      {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${adminToken}`,
+        },
+        body: JSON.stringify({
+          updateAllRecorrences: true,
+          sessaoRealizada: true,
+          valorAgendamento: 190,
+        }),
+      },
+    );
+
+    expect(ativarSessoesRes.status).toBe(200);
+    const ativarSessoesBody = await ativarSessoesRes.json();
+    const agendamentosRecorrentes = ativarSessoesBody.data;
+
+    for (const item of agendamentosRecorrentes) {
+      const sessoes = await sessaoModel.getFiltered({
+        agendamento_id: item.id,
+      });
+      expect(sessoes.length).toBeGreaterThan(0);
+      expect(sessoes[0].valorSessao).toBe(190);
+    }
+
+    const atualizarRes = await fetch(
+      `${BASE_URL}recurrences/${recurrenceId}/`,
+      {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${adminToken}`,
+        },
+        body: JSON.stringify({
+          updateAllRecorrences: true,
+          valorAgendamento: 325,
+        }),
+      },
+    );
+
+    expect(atualizarRes.status).toBe(200);
+
+    const atualizarBody = await atualizarRes.json();
+    expect(Array.isArray(atualizarBody.data)).toBe(true);
+    expect(atualizarBody.data.length).toBeGreaterThan(0);
+
+    for (const item of atualizarBody.data) {
+      const sessoes = await sessaoModel.getFiltered({
+        agendamento_id: item.id,
+      });
+
+      expect(sessoes.length).toBeGreaterThan(0);
+      expect(sessoes[0].valorSessao).toBe(325);
+    }
   });
 
   test("Deve negar edição recorrente sem autenticação", async () => {


### PR DESCRIPTION
## Resumo
Corrige a sincronização do valor financeiro ao editar agendamentos, garantindo atualização consistente da sessão/NF sem depender de alternar `sessaoRealizada`.

## O que foi alterado
- Ajuste no `PUT /api/v1/agendamentos/[id]` para sincronizar sessão associada também quando apenas o valor do agendamento muda.
- Ajuste no `PUT /api/v1/agendamentos/recurrences/[id]` para aplicar a mesma lógica em atualizações de recorrência.
- Inclusão/ajuste de testes de integração cobrindo:
  - sincronização de valor na edição,
  - não criação indevida de sessão,
  - falha com resposta 500 em erro de persistência,
  - sincronização em recorrências.

## Validação
- Suite focada de integração para agendamentos (`put.test.js`) passou.
- Regressão completa (`npm run test`) passou.

Closes #151

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session management logic for appointments to properly sync sessions based on appointment status and completion state
  * Enhanced error handling for recurring appointment updates to prevent silent failures
  * Fixed session value synchronization when appointment details are modified

* **Tests**
  * Added comprehensive integration tests to verify session synchronization behavior during appointment updates

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/danilo-marra/espaco-dialogico/pull/157?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->