### PR TITLE
Test: cover default nota fiscal in session GET

### DIFF
--- a/tests/integration/api/v1/sessoes/get-access.test.js
+++ b/tests/integration/api/v1/sessoes/get-access.test.js
@@ -109,7 +109,6 @@ beforeAll(async () => {
     valorSessao: 150,
     pagamento_realizado: false,
     repasse_realizado: false,
-    nota_fiscal: "Não Emitida",
   });
 
   sessaoId = sessao.id;
@@ -134,6 +133,8 @@ describe("GET /api/v1/sessoes/[id] - autorização", () => {
     expect(body).toHaveProperty("id", sessaoId);
     expect(body).toHaveProperty("terapeuta_id");
     expect(body).toHaveProperty("paciente_id");
+    expect(body).toHaveProperty("notaFiscal", "Não Emitida");
+    expect(body).toHaveProperty("pagamentoRealizado", false);
   });
 
   test("deve retornar 200 para terapeuta dono da sessão", async () => {


### PR DESCRIPTION
This PR adjusts the existing GET integration test for sessions so it exercises the real default behavior for `nota_fiscal`.

What changed:
- Creates the session without sending `nota_fiscal`
- Asserts the GET response returns `notaFiscal: "Não Emitida"`
- Keeps the existing auth coverage for 200/401/403

Validation:
- `npx jest --runInBand --verbose tests/integration/api/v1/sessoes/get-access.test.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced integration test assertions for session retrieval to verify additional response field values, ensuring API responses meet expected specifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/danilo-marra/espaco-dialogico/pull/158?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->