### PR TITLE
fix(admin): usar id de usuario em edicao e exclusao

### DIFF
--- a/pages/dashboard/usuarios/index.tsx
+++ b/pages/dashboard/usuarios/index.tsx
@@ -117,17 +117,14 @@ export default function UsersPage() {
         return;
       }
 
-      const response = await fetch(
-        `/api/v1/admin/users/${selectedUser.username}`,
-        {
-          method: "PUT",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
-          },
-          body: JSON.stringify(payload),
+      const response = await fetch(`/api/v1/admin/users/${selectedUser.id}`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
         },
-      );
+        body: JSON.stringify(payload),
+      });
 
       const data = await response.json();
 
@@ -150,15 +147,12 @@ export default function UsersPage() {
 
     try {
       const token = localStorage.getItem("authToken");
-      const response = await fetch(
-        `/api/v1/admin/users/${selectedUser.username}`,
-        {
-          method: "DELETE",
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
+      const response = await fetch(`/api/v1/admin/users/${selectedUser.id}`, {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${token}`,
         },
-      );
+      });
 
       if (!response.ok) {
         const data = await response.json();


### PR DESCRIPTION
## Resumo
This pull request updates the way user-specific API endpoints are constructed in the `UsersPage` component. Instead of using the `username` property to identify users in API requests, it now uses the user's `id`. This change improves consistency and reliability when performing update and delete operations on users.

**API Endpoint Updates:**

* Changed the user identifier in the API endpoint for updating a user from `selectedUser.username` to `selectedUser.id` in the `PUT` request.
* Changed the user identifier in the API endpoint for deleting a user from `selectedUser.username` to `selectedUser.id` in the `DELETE` request.
altera chamadas de update e delete de usuarios no dashboard para usar id imutavel\n- evita falhas quando username/email mudam\n\n## Validacao\n- npm run test:single -- tests/integration/api/v1/admin/users/put.test.js\n\n## Contexto\n- corrige comportamento no fluxo de edicao de usuarios admin