### PR TITLE
fix: melhorar entregabilidade do email de convite

### DIFF
--- a/pages/api/v1/invites/send-email.js
+++ b/pages/api/v1/invites/send-email.js
@@ -98,9 +98,9 @@ async function handler(request, response) {
     }
 
     const mailOptions = {
-      from: `Espaco Dialogico - Sistema <${senderAddress}>`,
+      from: `Espaço Dialógico <${senderAddress}>`,
       to: inviteData.email,
-      subject: `Convite para o Espaco Dialogico - ${inviteData.code}`,
+      subject: "Você recebeu um convite para o Espaço Dialógico",
       html: createInviteEmailTemplate(
         inviteData.code,
         senderName,

--- a/utils/emailTemplates/inviteTemplate.js
+++ b/utils/emailTemplates/inviteTemplate.js
@@ -9,7 +9,7 @@ function createInviteEmailTemplate(inviteCode, senderName, expiresAt, role) {
     admin: "Administrador",
   };
 
-  const roleName = roleNames[role] || "Usuario";
+  const roleName = roleNames[role] || "Usuário";
 
   const expirationDate = new Date(expiresAt).toLocaleDateString("pt-BR", {
     day: "2-digit",
@@ -25,20 +25,24 @@ function createInviteEmailTemplate(inviteCode, senderName, expiresAt, role) {
       <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>Convite - Espaco Dialogico</title>
+        <title>Convite - Espaço Dialógico</title>
       </head>
       <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
         <div style="background-color: #f9f9f9; padding: 30px; border-radius: 10px; border: 1px solid #ddd;">
-          <h1 style="color: #2563eb; text-align: center;">Voce foi convidado</h1>
+          <h1 style="color: #2563eb; text-align: center;">Você recebeu um convite</h1>
 
-          <p>Ola,</p>
+          <p>Olá,</p>
           <p>
-            <strong>${senderName}</strong> convidou voce para acessar o Espaco Dialogico com a funcao de
+            Você recebeu este convite porque um administrador cadastrou seu email no Espaço Dialógico.
+          </p>
+          <p>
+            O convite permite acessar o sistema com a função de
             <strong>${roleName}</strong>.
           </p>
 
-          <p><strong>Codigo do convite:</strong> ${inviteCode}</p>
+          <p><strong>Código do convite:</strong> ${inviteCode}</p>
           <p><strong>Validade:</strong> ${expirationDate}</p>
+          <p><strong>Enviado por:</strong> ${senderName}</p>
 
           <p style="margin: 24px 0;">
             <a
@@ -49,8 +53,8 @@ function createInviteEmailTemplate(inviteCode, senderName, expiresAt, role) {
             </a>
           </p>
 
-          <p>Se voce nao esperava este convite, desconsidere este email.</p>
-          <p style="margin-top: 24px; font-size: 12px; color: #666;">Equipe Espaco Dialogico</p>
+          <p>Se você não esperava este convite, desconsidere este email.</p>
+          <p style="margin-top: 24px; font-size: 12px; color: #666;">Equipe Espaço Dialógico</p>
         </div>
       </body>
     </html>
@@ -66,9 +70,9 @@ function createInviteEmailText(inviteCode, senderName, expiresAt, role) {
     admin: "Administrador",
   };
 
-  const roleName = roleNames[role] || "Usuario";
+  const roleName = roleNames[role] || "Usuário";
 
-  return `${senderName} convidou voce para o Espaco Dialogico.\n\nCodigo: ${inviteCode}\nFuncao: ${roleName}\nExpira em: ${new Date(expiresAt).toLocaleString("pt-BR")}\n\nLink: ${inviteLink}\n\nSe voce nao esperava este convite, ignore este email.`;
+  return `Você recebeu um convite para o Espaço Dialógico.\n\nVocê recebeu este convite porque um administrador cadastrou seu email no Espaço Dialógico.\n\nCódigo: ${inviteCode}\nFunção: ${roleName}\nExpira em: ${new Date(expiresAt).toLocaleString("pt-BR")}\nEnviado por: ${senderName}\n\nLink: ${inviteLink}\n\nSe você não esperava este convite, ignore este email.`;
 }
 
 export { createInviteEmailTemplate, createInviteEmailText };


### PR DESCRIPTION
## Resumo

- remove o código do convite do assunto do email
- atualiza remetente visível, assunto e template com acentuação correta
- adiciona contexto mais claro no corpo do convite antes do link
- mantém o usuário remetente como informação secundária em `Enviado por`

## Validação

- Testes locais informados como aprovados
- Hooks do commit: `secretlint`, `eslint --max-warnings=0`, `prettier --write`
- Validação focada anterior: ESLint nos arquivos alterados e `git diff --check`

Closes #150