### PR TITLE
perf: eliminar roundtrips extras em create/update de agendamento e paciente

### DIFF
--- a/models/agendamento.js
+++ b/models/agendamento.js
@@ -133,32 +133,58 @@ async function create(agendamentoData) {
     // Garantir booleano para o campo falta
     const falta = !!agendamentoData.falta;
 
-    // Inserir o agendamento no banco de dados
     const result = await database.query({
       text: `
-        INSERT INTO agendamentos (
-          terapeuta_id,
-          paciente_id,
-          recurrence_id,
-          data_agendamento,
-          horario_agendamento,
-          local_agendamento,
-          modalidade_agendamento,
-          tipo_agendamento,
-          valor_agendamento,
-          status_agendamento,
-          observacoes_agendamento,
-          sessao_realizada,
-          falta
+        WITH inserted AS (
+          INSERT INTO agendamentos (
+            terapeuta_id,
+            paciente_id,
+            recurrence_id,
+            data_agendamento,
+            horario_agendamento,
+            local_agendamento,
+            modalidade_agendamento,
+            tipo_agendamento,
+            valor_agendamento,
+            status_agendamento,
+            observacoes_agendamento,
+            sessao_realizada,
+            falta
+          )
+          VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+          RETURNING *
         )
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
-        RETURNING *
+        SELECT
+          inserted.*,
+          t.nome as terapeuta_nome,
+          t.foto as terapeuta_foto,
+          t.telefone as terapeuta_telefone,
+          t.email as terapeuta_email,
+          t.crp as terapeuta_crp,
+          t.dt_nascimento as terapeuta_dt_nascimento,
+          t.dt_entrada as terapeuta_dt_entrada,
+          t.chave_pix as terapeuta_chave_pix,
+          p.nome as paciente_nome,
+          p.dt_nascimento as paciente_dt_nascimento,
+          p.nome_responsavel as paciente_nome_responsavel,
+          p.telefone_responsavel as paciente_telefone_responsavel,
+          p.nf_nome_completo as paciente_nf_nome_completo,
+          p.nf_telefone as paciente_nf_telefone,
+          p.nf_cpf as paciente_nf_cpf,
+          p.nf_email as paciente_nf_email,
+          p.nf_endereco as paciente_nf_endereco,
+          p.nf_dt_entrada as paciente_nf_dt_entrada,
+          p.origem as paciente_origem,
+          p.dt_entrada as paciente_dt_entrada
+        FROM inserted
+        JOIN terapeutas t ON inserted.terapeuta_id = t.id
+        JOIN pacientes p ON inserted.paciente_id = p.id
       `,
       values: [
         agendamentoData.terapeuta_id,
         agendamentoData.paciente_id,
         agendamentoData.recurrenceId,
-        dataFormatada, // Usar a data formatada de forma segura
+        dataFormatada,
         agendamentoData.horarioAgendamento,
         agendamentoData.localAgendamento,
         agendamentoData.modalidadeAgendamento,
@@ -171,8 +197,7 @@ async function create(agendamentoData) {
       ],
     });
 
-    // Retornar agendamento com informações completas
-    return await getById(result.rows[0].id);
+    return formatAgendamentoResult(result.rows[0]);
   } catch (error) {
     console.error("Erro ao inserir agendamento no banco:", {
       message: error.message,
@@ -1106,15 +1131,10 @@ async function updateAllByRecurrenceIdWithNewWeekday(
 }
 
 async function update(id, agendamentoData) {
-  // Verificar se o agendamento existe
-  await getById(id);
-
-  // Preparar os campos a serem atualizados
   const fieldsToUpdate = [];
   const values = [];
   let paramCounter = 1;
 
-  // Função auxiliar para adicionar campos a serem atualizados
   function addField(fieldName, value) {
     if (value !== undefined) {
       fieldsToUpdate.push(`${fieldName} = $${paramCounter}`);
@@ -1123,7 +1143,6 @@ async function update(id, agendamentoData) {
     }
   }
 
-  // Adicionar cada campo que precisa ser atualizado
   addField("paciente_id", agendamentoData.paciente_id);
   addField("terapeuta_id", agendamentoData.terapeuta_id);
   addField("data_agendamento", agendamentoData.dataAgendamento);
@@ -1138,30 +1157,56 @@ async function update(id, agendamentoData) {
   addField("falta", agendamentoData.falta);
   addField("recurrence_id", agendamentoData.recurrenceId);
 
-  // Se não houver campos para atualizar, retornar os dados atuais
   if (fieldsToUpdate.length === 0) {
     return await getById(id);
   }
 
-  // Adicionar o id para a cláusula WHERE
   values.push(id);
 
-  // Construir a query SQL
-  const sql = `
-    UPDATE agendamentos
-    SET ${fieldsToUpdate.join(", ")}, updated_at = NOW()
-    WHERE id = $${paramCounter}
-    RETURNING *
-  `;
-
-  // Executar a query
-  await database.query({
-    text: sql,
-    values: values,
+  const result = await database.query({
+    text: `
+      WITH updated AS (
+        UPDATE agendamentos
+        SET ${fieldsToUpdate.join(", ")}, updated_at = NOW()
+        WHERE id = $${paramCounter}
+        RETURNING *
+      )
+      SELECT
+        updated.*,
+        t.nome as terapeuta_nome,
+        t.foto as terapeuta_foto,
+        t.telefone as terapeuta_telefone,
+        t.email as terapeuta_email,
+        t.crp as terapeuta_crp,
+        t.dt_nascimento as terapeuta_dt_nascimento,
+        t.dt_entrada as terapeuta_dt_entrada,
+        t.chave_pix as terapeuta_chave_pix,
+        p.nome as paciente_nome,
+        p.dt_nascimento as paciente_dt_nascimento,
+        p.nome_responsavel as paciente_nome_responsavel,
+        p.telefone_responsavel as paciente_telefone_responsavel,
+        p.nf_nome_completo as paciente_nf_nome_completo,
+        p.nf_telefone as paciente_nf_telefone,
+        p.nf_cpf as paciente_nf_cpf,
+        p.nf_email as paciente_nf_email,
+        p.nf_endereco as paciente_nf_endereco,
+        p.nf_dt_entrada as paciente_nf_dt_entrada,
+        p.origem as paciente_origem,
+        p.dt_entrada as paciente_dt_entrada
+      FROM updated
+      JOIN terapeutas t ON updated.terapeuta_id = t.id
+      JOIN pacientes p ON updated.paciente_id = p.id
+    `,
+    values,
   });
 
-  // Retornar os dados atualizados
-  return await getById(id);
+  if (result.rowCount === 0) {
+    throw new NotFoundError({
+      message: "Agendamento não encontrado",
+    });
+  }
+
+  return formatAgendamentoResult(result.rows[0]);
 }
 
 async function remove(id) {

--- a/models/paciente.js
+++ b/models/paciente.js
@@ -209,37 +209,41 @@ function formatPacienteResult(row) {
 }
 
 async function update(id, pacienteInputValues) {
-  // Primeiro, buscar o paciente existente
-  const currentPaciente = await getById(id);
-
-  // Se não encontrar o paciente, lançar erro
-  if (!currentPaciente) {
-    throw new NotFoundError({
-      message: "Paciente não encontrado",
-      action: "Verifique o ID e tente novamente",
-    });
-  }
-
-  const queryObject = {
+  const result = await database.query({
     text: `
-      UPDATE pacientes
-      SET
-        nome = $1,
-        dt_nascimento = $2,
-        terapeuta_id = $3,
-        nome_responsavel = $4,
-        telefone_responsavel = $5,
-        origem = $6,
-        dt_entrada = $7,
-        nf_nome_completo = $8,
-        nf_telefone = $9,
-        nf_cpf = $10,
-        nf_email = $11,
-        nf_endereco = $12,
-        nf_dt_entrada = $13,
-        updated_at = timezone('utc', now())
-      WHERE id = $14
-      RETURNING *
+      WITH updated AS (
+        UPDATE pacientes
+        SET
+          nome = $1,
+          dt_nascimento = $2,
+          terapeuta_id = $3,
+          nome_responsavel = $4,
+          telefone_responsavel = $5,
+          origem = $6,
+          dt_entrada = $7,
+          nf_nome_completo = $8,
+          nf_telefone = $9,
+          nf_cpf = $10,
+          nf_email = $11,
+          nf_endereco = $12,
+          nf_dt_entrada = $13,
+          updated_at = timezone('utc', now())
+        WHERE id = $14
+        RETURNING *
+      )
+      SELECT
+        updated.*,
+        t.id as terapeuta_id,
+        t.nome as terapeuta_nome,
+        t.telefone as terapeuta_telefone,
+        t.email as terapeuta_email,
+        t.crp as terapeuta_crp,
+        t.dt_nascimento as terapeuta_dt_nascimento,
+        t.dt_entrada as terapeuta_dt_entrada,
+        t.chave_pix as terapeuta_chave_pix,
+        t.foto as terapeuta_foto
+      FROM updated
+      LEFT JOIN terapeutas t ON updated.terapeuta_id = t.id
     `,
     values: [
       pacienteInputValues.nome,
@@ -257,10 +261,16 @@ async function update(id, pacienteInputValues) {
       pacienteInputValues.nf_dt_entrada,
       id,
     ],
-  };
+  });
 
-  const result = await database.query(queryObject);
-  return result.rows[0];
+  if (result.rowCount === 0) {
+    throw new NotFoundError({
+      message: "Paciente não encontrado",
+      action: "Verifique o ID e tente novamente",
+    });
+  }
+
+  return formatPacienteResult(result.rows[0]);
 }
 
 async function remove(id) {


### PR DESCRIPTION
## Resumo

- **`agendamento.create()`** — 4 → 3 queries: substitui `INSERT RETURNING *` + `getById()` separados por uma CTE que insere e já retorna com `JOIN terapeutas/pacientes` em uma única query.
- **`agendamento.update()`** — 3 → 1 query: o fluxo anterior fazia `getById()` (check), `UPDATE` (resultado descartado) e `getById()` (retorno). Substituído por CTE `UPDATE … JOIN terapeutas JOIN pacientes`; se 0 linhas afetadas, lança `NotFoundError`.
- **`paciente.update()`** — 2 → 1 query no model: remove `getById()` redundante (a API já havia buscado o registro) e substitui `UPDATE RETURNING *` (sem join) por CTE com `LEFT JOIN terapeutas` + `formatPacienteResult()`, corrigindo também o shape de resposta do `PUT /pacientes/:id` que antes retornava linha crua sem `terapeutaInfo`.

## Contexto

Task 9 da issue #149 (performance). As demais tasks já foram concluídas nas PRs #165 e #166.

## Plano de testes

- [x] `POST /api/v1/agendamentos` — verifica que o retorno inclui `terapeutaInfo` e `pacienteInfo` sem query extra
- [x] `PUT /api/v1/agendamentos/:id` — verifica que o retorno é o agendamento atualizado com joins
- [x] `PUT /api/v1/pacientes/:id` — verifica que o retorno inclui `terapeutaInfo` corretamente formatado
- [x] Suite completa: `npm test` sem regressões

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized database queries for appointment and patient data retrieval to enhance performance and reduce server round-trips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->